### PR TITLE
Ensure an errors.ExitCoder is returned in run

### DIFF
--- a/template/cmd/{{Executable}}/main.go
+++ b/template/cmd/{{Executable}}/main.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/drone-plugins/drone-plugin-lib/errors"
@@ -44,11 +43,19 @@ func run(ctx *cli.Context) error {
 	)
 
 	if err := plugin.Validate(); err != nil {
-		return err
+		if e, ok := err.(errors.ExitCoder); ok {
+			return e
+		}
+
+		return errors.ExitMessagef("validation failed: %w", err)
 	}
 
 	if err := plugin.Execute(); err != nil {
-		return err
+		if e, ok := err.(errors.ExitCoder); ok {
+			return e
+		}
+
+		return errors.ExitMessagef("execution failed: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
When the value returned from Validate or Execute was just an error nothing would be printed to the console. Check to see if the value returned by the plugin is an ExitCoder and if not create an ExitCoder to ensure the user is notified as to what happened during the run.