### PR TITLE
Add a default renovate config

### DIFF
--- a/template/renovate.json
+++ b/template/renovate.json
@@ -1,0 +1,26 @@
+{
+    "extends": [
+        "config:base",
+        ":automergeMinor",
+        ":automergeDigest"
+    ],
+    "enabledManagers": [
+        "dockerfile",
+        "gomod"
+    ],
+    "dockerfile": {
+        "fileMatch": [
+            "docker/Dockerfile\\.linux\\.(arm|arm64|amd64|multiarch)",
+            "docker/Dockerfile\\.windows\\.(1809|1903|1909|2004)"
+        ],
+        "pinDigests": true
+    },
+    "gomod": {
+        "postUpdateOptions": [
+            "gomodTidy"
+        ]
+    },
+    "labels": [
+        "renovate"
+    ]
+}


### PR DESCRIPTION
The config is setup to pin the Dockerfile digests and to automerge them. Additionally it will update Golang dependencies, making sure to tidy up afterwards. Minor revisions of libraries are set to automerge if the build passes. Major revisions need to be reviewed.