### PR TITLE
Remove dryrun

### DIFF
--- a/template/.drone.star
+++ b/template/.drone.star
@@ -51,7 +51,6 @@ def testing(ctx):
             {
                 "name": "lint",
                 "image": "golang:1.15",
-                "pull": "always",
                 "commands": [
                     "go run golang.org/x/lint/golint -set_exit_status ./...",
                 ],
@@ -65,7 +64,6 @@ def testing(ctx):
             {
                 "name": "vet",
                 "image": "golang:1.15",
-                "pull": "always",
                 "commands": [
                     "go vet ./...",
                 ],
@@ -79,7 +77,6 @@ def testing(ctx):
             {
                 "name": "test",
                 "image": "golang:1.15",
-                "pull": "always",
                 "commands": [
                     "go test -cover ./...",
                 ],
@@ -132,7 +129,6 @@ def linux(ctx, arch):
         {
             "name": "build",
             "image": "golang:1.15",
-            "pull": "always",
             "environment": {
                 "CGO_ENABLED": "0",
             },
@@ -141,7 +137,6 @@ def linux(ctx, arch):
         {
             "name": "executable",
             "image": "golang:1.15",
-            "pull": "always",
             "commands": [
                 "./release/linux/%s/{{ Executable }} --help" % (arch),
             ],
@@ -152,7 +147,6 @@ def linux(ctx, arch):
         steps.append({
             "name": "docker",
             "image": "plugins/docker",
-            "pull": "always",
             "settings": {
                 "dockerfile": "docker/Dockerfile.linux.%s" % (arch),
                 "repo": "{{ DockerOwner }}/{{ DockerRepo }}",
@@ -289,7 +283,6 @@ def manifest(ctx):
             {
                 "name": "manifest",
                 "image": "plugins/manifest",
-                "pull": "always",
                 "settings": {
                     "auto_tag": "true",
                     "username": {
@@ -305,7 +298,6 @@ def manifest(ctx):
             {
                 "name": "microbadger",
                 "image": "plugins/webhook",
-                "pull": "always",
                 "settings": {
                     "urls": {
                         "from_secret": "microbadger_url",
@@ -334,7 +326,6 @@ def gitter(ctx):
             {
                 "name": "gitter",
                 "image": "plugins/gitter",
-                "pull": "always",
                 "settings": {
                     "webhook": {
                         "from_secret": "gitter_webhook",

--- a/template/.drone.star
+++ b/template/.drone.star
@@ -1,362 +1,364 @@
 def main(ctx):
-  before = testing(ctx)
+    before = testing(ctx)
 
-  stages = [
-    linux(ctx, 'amd64'),
-    linux(ctx, 'arm64'),
-    linux(ctx, 'arm'),
+    stages = [
+        linux(ctx, "amd64"),
+        linux(ctx, "arm64"),
+        linux(ctx, "arm"),
 {{- if UseWindows }}
-    windows(ctx, '1909'),
-    windows(ctx, '1903'),
-    windows(ctx, '1809'),
+        windows(ctx, "1909"),
+        windows(ctx, "1903"),
+        windows(ctx, "1809"),
 {{- end }}
-  ]
+    ]
 
-  after = manifest(ctx) + gitter(ctx)
+    after = manifest(ctx) + gitter(ctx)
 
-  for b in before:
+    for b in before:
+        for s in stages:
+            s["depends_on"].append(b["name"])
+
     for s in stages:
-      s['depends_on'].append(b['name'])
+        for a in after:
+            a["depends_on"].append(s["name"])
 
-  for s in stages:
-    for a in after:
-      a['depends_on'].append(s['name'])
-
-  return before + stages + after
+    return before + stages + after
 
 def testing(ctx):
-  return [{
-    'kind': 'pipeline',
-    'type': 'docker',
-    'name': 'testing',
-    'platform': {
-      'os': 'linux',
-      'arch': 'amd64',
-    },
-    'steps': [
-      {
-        'name': 'staticcheck',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'commands': [
-          'go run honnef.co/go/tools/cmd/staticcheck ./...',
+    return [{
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "testing",
+        "platform": {
+            "os": "linux",
+            "arch": "amd64",
+        },
+        "steps": [
+            {
+                "name": "staticcheck",
+                "image": "golang:1.15",
+                "pull": "always",
+                "commands": [
+                    "go run honnef.co/go/tools/cmd/staticcheck ./...",
+                ],
+                "volumes": [
+                    {
+                        "name": "gopath",
+                        "path": "/go",
+                    },
+                ],
+            },
+            {
+                "name": "lint",
+                "image": "golang:1.15",
+                "pull": "always",
+                "commands": [
+                    "go run golang.org/x/lint/golint -set_exit_status ./...",
+                ],
+                "volumes": [
+                    {
+                        "name": "gopath",
+                        "path": "/go",
+                    },
+                ],
+            },
+            {
+                "name": "vet",
+                "image": "golang:1.15",
+                "pull": "always",
+                "commands": [
+                    "go vet ./...",
+                ],
+                "volumes": [
+                    {
+                        "name": "gopath",
+                        "path": "/go",
+                    },
+                ],
+            },
+            {
+                "name": "test",
+                "image": "golang:1.15",
+                "pull": "always",
+                "commands": [
+                    "go test -cover ./...",
+                ],
+                "volumes": [
+                    {
+                        "name": "gopath",
+                        "path": "/go",
+                    },
+                ],
+            },
         ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/go',
-          },
+        "volumes": [
+            {
+                "name": "gopath",
+                "temp": {},
+            },
         ],
-      },
-      {
-        'name': 'lint',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'commands': [
-          'go run golang.org/x/lint/golint -set_exit_status ./...',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/go',
-          },
-        ],
-      },
-      {
-        'name': 'vet',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'commands': [
-          'go vet ./...',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/go',
-          },
-        ],
-      },
-      {
-        'name': 'test',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'commands': [
-          'go test -cover ./...',
-        ],
-        'volumes': [
-          {
-            'name': 'gopath',
-            'path': '/go',
-          },
-        ],
-      },
-    ],
-    'volumes': [
-      {
-        'name': 'gopath',
-        'temp': {},
-      },
-    ],
-    'trigger': {
-      'ref': [
-        'refs/heads/master',
-        'refs/tags/**',
-        'refs/pull/**',
-      ],
-    },
-  }]
+        "trigger": {
+            "ref": [
+                "refs/heads/master",
+                "refs/tags/**",
+                "refs/pull/**",
+            ],
+        },
+    }]
 
 def linux(ctx, arch):
-  docker = {
-    'dockerfile': 'docker/Dockerfile.linux.%s' % (arch),
-    'repo': '{{ DockerOwner }}/{{ DockerRepo }}',
-    'username': {
-      'from_secret': 'docker_username',
-    },
-    'password': {
-      'from_secret': 'docker_password',
-    },
-  }
-
-  if ctx.build.event == 'pull_request':
-    docker.update({
-      'dry_run': True,
-      'tags': 'linux-%s' % (arch),
-    })
-  else:
-    docker.update({
-      'auto_tag': True,
-      'auto_tag_suffix': 'linux-%s' % (arch),
-    })
-
-  if ctx.build.event == 'tag':
-    build = [
-      'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/linux/%s/{{ Executable }} ./cmd/{{ Executable }}' % (ctx.build.ref.replace("refs/tags/v", ""), arch),
-    ]
-  else:
-    build = [
-      'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/linux/%s/{{ Executable }} ./cmd/{{ Executable }}' % (ctx.build.commit[0:8], arch),
-    ]
-
-  return {
-    'kind': 'pipeline',
-    'type': 'docker',
-    'name': 'linux-%s' % (arch),
-    'platform': {
-      'os': 'linux',
-      'arch': arch,
-    },
-    'steps': [
-      {
-        'name': 'environment',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'environment': {
-          'CGO_ENABLED': '0',
+    docker = {
+        "dockerfile": "docker/Dockerfile.linux.%s" % (arch),
+        "repo": "{{ DockerOwner }}/{{ DockerRepo }}",
+        "username": {
+            "from_secret": "docker_username",
         },
-        'commands': [
-          'go version',
-          'go env',
-        ],
-      },
-      {
-        'name': 'build',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'environment': {
-          'CGO_ENABLED': '0',
+        "password": {
+            "from_secret": "docker_password",
         },
-        'commands': build,
-      },
-      {
-        'name': 'executable',
-        'image': 'golang:1.15',
-        'pull': 'always',
-        'commands': [
-          './release/linux/%s/{{ Executable }} --help' % (arch),
+    }
+
+    if ctx.build.event == "pull_request":
+        docker.update({
+            "dry_run": True,
+            "tags": "linux-%s" % (arch),
+        })
+    else:
+        docker.update({
+            "auto_tag": True,
+            "auto_tag_suffix": "linux-%s" % (arch),
+        })
+
+    if ctx.build.event == "tag":
+        build = [
+            'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/linux/%s/{{ Executable }} ./cmd/{{ Executable }}' % (ctx.build.ref.replace("refs/tags/v", ""), arch),
+        ]
+    else:
+        build = [
+            'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/linux/%s/{{ Executable }} ./cmd/{{ Executable }}' % (ctx.build.commit[0:8], arch),
+        ]
+
+    return {
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "linux-%s" % (arch),
+        "platform": {
+            "os": "linux",
+            "arch": arch,
+        },
+        "steps": [
+            {
+                "name": "environment",
+                "image": "golang:1.15",
+                "pull": "always",
+                "environment": {
+                    "CGO_ENABLED": "0",
+                },
+                "commands": [
+                    "go version",
+                    "go env",
+                ],
+            },
+            {
+                "name": "build",
+                "image": "golang:1.15",
+                "pull": "always",
+                "environment": {
+                    "CGO_ENABLED": "0",
+                },
+                "commands": build,
+            },
+            {
+                "name": "executable",
+                "image": "golang:1.15",
+                "pull": "always",
+                "commands": [
+                    "./release/linux/%s/{{ Executable }} --help" % (arch),
+                ],
+            },
+            {
+                "name": "docker",
+                "image": "plugins/docker",
+                "pull": "always",
+                "settings": docker,
+            },
         ],
-      },
-      {
-        'name': 'docker',
-        'image': 'plugins/docker',
-        'pull': 'always',
-        'settings': docker,
-      },
-    ],
-    'depends_on': [],
-    'trigger': {
-      'ref': [
-        'refs/heads/master',
-        'refs/tags/**',
-        'refs/pull/**',
-      ],
-    },
-  }
+        "depends_on": [],
+        "trigger": {
+            "ref": [
+                "refs/heads/master",
+                "refs/tags/**",
+                "refs/pull/**",
+            ],
+        },
+    }
+
 {{- if UseWindows }}
 
 def windows(ctx, version):
-  docker = [
-    'echo $env:PASSWORD | docker login --username $env:USERNAME --password-stdin',
-  ]
-
-  if ctx.build.event == 'tag':
-    build = [
-      'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/windows/amd64/{{ Executable }}.exe ./cmd/{{ Executable }}' % (ctx.build.ref.replace("refs/tags/v", "")),
+    docker = [
+        "echo $env:PASSWORD | docker login --username $env:USERNAME --password-stdin",
     ]
 
-    docker = docker + [
-      'docker build --pull -f docker/Dockerfile.windows.%s -t {{ DockerOwner }}/{{ DockerRepo }}:%s-windows-%s-amd64 .' % (version, ctx.build.ref.replace("refs/tags/v", ""), version),
-      'docker run --rm {{ DockerOwner }}/{{ DockerRepo }}:%s-windows-%s-amd64 --help' % (ctx.build.ref.replace("refs/tags/v", ""), version),
-      'docker push {{ DockerOwner }}/{{ DockerRepo }}:%s-windows-%s-amd64' % (ctx.build.ref.replace("refs/tags/v", ""), version),
-    ]
-  else:
-    build = [
-      'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/windows/amd64/{{ Executable }}.exe ./cmd/{{ Executable }}' % (ctx.build.commit[0:8]),
-    ]
+    if ctx.build.event == "tag":
+        build = [
+            'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/windows/amd64/{{ Executable }}.exe ./cmd/{{ Executable }}' % (ctx.build.ref.replace("refs/tags/v", "")),
+        ]
 
-    docker = docker + [
-      'docker build --pull -f docker/Dockerfile.windows.%s -t {{ DockerOwner }}/{{ DockerRepo }}:windows-%s-amd64 .' % (version, version),
-      'docker run --rm {{ DockerOwner }}/{{ DockerRepo }}:windows-%s-amd64 --help' % (version),
-      'docker push {{ DockerOwner }}/{{ DockerRepo }}:windows-%s-amd64' % (version),
-    ]
+        docker = docker + [
+            "docker build --pull -f docker/Dockerfile.windows.%s -t {{ DockerOwner }}/{{ DockerRepo }}:%s-windows-%s-amd64 ." % (version, ctx.build.ref.replace("refs/tags/v", ""), version),
+            "docker run --rm {{ DockerOwner }}/{{ DockerRepo }}:%s-windows-%s-amd64 --help" % (ctx.build.ref.replace("refs/tags/v", ""), version),
+            "docker push {{ DockerOwner }}/{{ DockerRepo }}:%s-windows-%s-amd64" % (ctx.build.ref.replace("refs/tags/v", ""), version),
+        ]
+    else:
+        build = [
+            'go build -v -ldflags "-X main.version=%s" -a -tags netgo -o release/windows/amd64/{{ Executable }}.exe ./cmd/{{ Executable }}' % (ctx.build.commit[0:8]),
+        ]
 
-  return {
-    'kind': 'pipeline',
-    'type': 'ssh',
-    'name': 'windows-%s' % (version),
-    'platform': {
-      'os': 'windows',
-    },
-    'server': {
-      'host': {
-        'from_secret': 'windows_server_%s' % (version),
-      },
-      'user': {
-        'from_secret': 'windows_username',
-      },
-      'password': {
-        'from_secret': 'windows_password',
-      },
-    },
-    'steps': [
-      {
-        'name': 'environment',
-        'environment': {
-          'CGO_ENABLED': '0',
+        docker = docker + [
+            "docker build --pull -f docker/Dockerfile.windows.%s -t {{ DockerOwner }}/{{ DockerRepo }}:windows-%s-amd64 ." % (version, version),
+            "docker run --rm {{ DockerOwner }}/{{ DockerRepo }}:windows-%s-amd64 --help" % (version),
+            "docker push {{ DockerOwner }}/{{ DockerRepo }}:windows-%s-amd64" % (version),
+        ]
+
+    return {
+        "kind": "pipeline",
+        "type": "ssh",
+        "name": "windows-%s" % (version),
+        "platform": {
+            "os": "windows",
         },
-        'commands': [
-          'go version',
-          'go env',
+        "server": {
+            "host": {
+                "from_secret": "windows_server_%s" % (version),
+            },
+            "user": {
+                "from_secret": "windows_username",
+            },
+            "password": {
+                "from_secret": "windows_password",
+            },
+        },
+        "steps": [
+            {
+                "name": "environment",
+                "environment": {
+                    "CGO_ENABLED": "0",
+                },
+                "commands": [
+                    "go version",
+                    "go env",
+                ],
+            },
+            {
+                "name": "build",
+                "environment": {
+                    "CGO_ENABLED": "0",
+                },
+                "commands": build,
+            },
+            {
+                "name": "executable",
+                "commands": [
+                    "./release/windows/amd64/{{ Executable }}.exe --help",
+                ],
+            },
+            {
+                "name": "docker",
+                "environment": {
+                    "USERNAME": {
+                        "from_secret": "docker_username",
+                    },
+                    "PASSWORD": {
+                        "from_secret": "docker_password",
+                    },
+                },
+                "commands": docker,
+            },
         ],
-      },
-      {
-        'name': 'build',
-        'environment': {
-          'CGO_ENABLED': '0',
+        "depends_on": [],
+        "trigger": {
+            "ref": [
+                "refs/heads/master",
+                "refs/tags/**",
+            ],
         },
-        'commands': build,
-      },
-      {
-        'name': 'executable',
-        'commands': [
-          './release/windows/amd64/{{ Executable }}.exe --help',
-        ],
-      },
-      {
-        'name': 'docker',
-        'environment': {
-          'USERNAME': {
-            'from_secret': 'docker_username',
-          },
-          'PASSWORD': {
-            'from_secret': 'docker_password',
-          },
-        },
-        'commands': docker,
-      },
-    ],
-    'depends_on': [],
-    'trigger': {
-      'ref': [
-        'refs/heads/master',
-        'refs/tags/**',
-      ],
-    },
-  }
+    }
+
 {{- end }}
 
 def manifest(ctx):
-  return [{
-    'kind': 'pipeline',
-    'type': 'docker',
-    'name': 'manifest',
-    'steps': [
-      {
-        'name': 'manifest',
-        'image': 'plugins/manifest',
-        'pull': 'always',
-        'settings': {
-          'auto_tag': 'true',
-          'username': {
-            'from_secret': 'docker_username',
-          },
-          'password': {
-            'from_secret': 'docker_password',
-          },
-          'spec': 'docker/manifest.tmpl',
-          'ignore_missing': 'true',
+    return [{
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "manifest",
+        "steps": [
+            {
+                "name": "manifest",
+                "image": "plugins/manifest",
+                "pull": "always",
+                "settings": {
+                    "auto_tag": "true",
+                    "username": {
+                        "from_secret": "docker_username",
+                    },
+                    "password": {
+                        "from_secret": "docker_password",
+                    },
+                    "spec": "docker/manifest.tmpl",
+                    "ignore_missing": "true",
+                },
+            },
+            {
+                "name": "microbadger",
+                "image": "plugins/webhook",
+                "pull": "always",
+                "settings": {
+                    "urls": {
+                        "from_secret": "microbadger_url",
+                    },
+                },
+            },
+        ],
+        "depends_on": [],
+        "trigger": {
+            "ref": [
+                "refs/heads/master",
+                "refs/tags/**",
+            ],
         },
-      },
-      {
-        'name': 'microbadger',
-        'image': 'plugins/webhook',
-        'pull': 'always',
-        'settings': {
-          'urls': {
-            'from_secret': 'microbadger_url',
-          },
-        },
-      },
-    ],
-    'depends_on': [],
-    'trigger': {
-      'ref': [
-        'refs/heads/master',
-        'refs/tags/**',
-      ],
-    },
-  }]
+    }]
 
 def gitter(ctx):
-  return [{
-    'kind': 'pipeline',
-    'type': 'docker',
-    'name': 'gitter',
-    'clone': {
-      'disable': True,
-    },
-    'steps': [
-      {
-        'name': 'gitter',
-        'image': 'plugins/gitter',
-        'pull': 'always',
-        'settings': {
-          'webhook': {
-            'from_secret': 'gitter_webhook',
-          }
+    return [{
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "gitter",
+        "clone": {
+            "disable": True,
         },
-      },
-    ],
-    'depends_on': [
-      'manifest',
-    ],
-    'trigger': {
-      'ref': [
-        'refs/heads/master',
-        'refs/tags/**',
-      ],
-      'status': [
-        'failure',
-      ],
-    },
-  }]
+        "steps": [
+            {
+                "name": "gitter",
+                "image": "plugins/gitter",
+                "pull": "always",
+                "settings": {
+                    "webhook": {
+                        "from_secret": "gitter_webhook",
+                    },
+                },
+            },
+        ],
+        "depends_on": [
+            "manifest",
+        ],
+        "trigger": {
+            "ref": [
+                "refs/heads/master",
+                "refs/tags/**",
+            ],
+            "status": [
+                "failure",
+            ],
+        },
+    }]


### PR DESCRIPTION
Formats the `.drone.yml` using [buildifier](https://github.com/bazelbuild/buildtools/tree/master/buildifier) which is a formatter and linter for starlark files. Recently starlark decided to conform to [PEP 8](https://www.python.org/dev/peps/pep-0008) with regard to indentation so a lot of white space changes happened in the first commit.

In the second the `dry-run` was removed from the plugin build. Because the `dry-run` is unauthenticated it was constantly hitting API request limits.

In the third commit the `pull: always` was removed from everything but the first `golang` image step in a pipeline. This should speed up builds some as subsequent steps won't attempt to pull the image.