### PR TITLE
Update starlark config

### DIFF
--- a/template/.drone.star
+++ b/template/.drone.star
@@ -1,5 +1,7 @@
 """Starlark build for {{ RepoOwner }}/{{ RepoName }}."""
 
+_GO_VERSION = "1.15"
+
 def main(ctx):
     """Entrypoint for the build.
 
@@ -45,7 +47,7 @@ def _testing(ctx):
         "steps": [
             {
                 "name": "staticcheck",
-                "image": "golang:1.15",
+                "image": "golang:%s" % (_GO_VERSION),
                 "pull": "always",
                 "commands": [
                     "go run honnef.co/go/tools/cmd/staticcheck ./...",
@@ -59,7 +61,7 @@ def _testing(ctx):
             },
             {
                 "name": "lint",
-                "image": "golang:1.15",
+                "image": "golang:%s" % (_GO_VERSION),
                 "commands": [
                     "go run golang.org/x/lint/golint -set_exit_status ./...",
                 ],
@@ -72,7 +74,7 @@ def _testing(ctx):
             },
             {
                 "name": "vet",
-                "image": "golang:1.15",
+                "image": "golang:%s" % (_GO_VERSION),
                 "commands": [
                     "go vet ./...",
                 ],
@@ -85,7 +87,7 @@ def _testing(ctx):
             },
             {
                 "name": "test",
-                "image": "golang:1.15",
+                "image": "golang:%s" % (_GO_VERSION),
                 "commands": [
                     "go test -cover ./...",
                 ],
@@ -125,7 +127,7 @@ def _linux(ctx, arch):
     steps = [
         {
             "name": "environment",
-            "image": "golang:1.15",
+            "image": "golang:%s" % (_GO_VERSION),
             "pull": "always",
             "environment": {
                 "CGO_ENABLED": "0",
@@ -137,7 +139,7 @@ def _linux(ctx, arch):
         },
         {
             "name": "build",
-            "image": "golang:1.15",
+            "image": "golang:%s" % (_GO_VERSION),
             "environment": {
                 "CGO_ENABLED": "0",
             },
@@ -145,7 +147,7 @@ def _linux(ctx, arch):
         },
         {
             "name": "executable",
-            "image": "golang:1.15",
+            "image": "golang:%s" % (_GO_VERSION),
             "commands": [
                 "./release/linux/%s/{{ Executable }} --help" % (arch),
             ],

--- a/template/.drone.star
+++ b/template/.drone.star
@@ -313,36 +313,3 @@ def manifest(ctx):
             ],
         },
     }]
-
-def gitter(ctx):
-    return [{
-        "kind": "pipeline",
-        "type": "docker",
-        "name": "gitter",
-        "clone": {
-            "disable": True,
-        },
-        "steps": [
-            {
-                "name": "gitter",
-                "image": "plugins/gitter",
-                "settings": {
-                    "webhook": {
-                        "from_secret": "gitter_webhook",
-                    },
-                },
-            },
-        ],
-        "depends_on": [
-            "manifest",
-        ],
-        "trigger": {
-            "ref": [
-                "refs/heads/master",
-                "refs/tags/**",
-            ],
-            "status": [
-                "failure",
-            ],
-        },
-    }]

--- a/template/.drone.star
+++ b/template/.drone.star
@@ -46,11 +46,25 @@ def _testing(ctx):
         },
         "steps": [
             {
-                "name": "staticcheck",
+                "name": "modules",
                 "image": "golang:%s" % (_GO_VERSION),
                 "pull": "always",
                 "commands": [
-                    "go run honnef.co/go/tools/cmd/staticcheck ./...",
+                    "go get -d ./...",
+                ],
+                "volumes": [
+                    {
+                        "name": "gopath",
+                        "path": "/go",
+                    },
+                ],
+            },
+            {
+                "name": "staticcheck",
+                "image": "golang:%s" % (_GO_VERSION),
+                "commands": [
+                    "go get honnef.co/go/tools/cmd/staticcheck",
+                    "staticcheck ./...",
                 ],
                 "volumes": [
                     {
@@ -63,7 +77,8 @@ def _testing(ctx):
                 "name": "lint",
                 "image": "golang:%s" % (_GO_VERSION),
                 "commands": [
-                    "go run golang.org/x/lint/golint -set_exit_status ./...",
+                    "go get golang.org/x/lint/golint",
+                    "golint -set_exit_status ./...",
                 ],
                 "volumes": [
                     {


### PR DESCRIPTION
Fixes all the `buildifier` lints and formats the template. Sets the `golang` image version once so it can be changed easily. Removes the `gitter` pipeline since that really isn't used.